### PR TITLE
Add mirrored mode option on boot

### DIFF
--- a/sdcard/config.cfg
+++ b/sdcard/config.cfg
@@ -126,5 +126,5 @@ ENABLE_SAMBA=0
 ## Turn auto night mode on or off (0/1)
 AUTO_NIGHT_MODE=0
 
-## Mirror camera (0/1)
-MIRRORED=0
+## Ceiling camera mode when the image is flipped and mirrored (0/1)
+CEILING_MODE=0

--- a/sdcard/config.cfg
+++ b/sdcard/config.cfg
@@ -125,3 +125,6 @@ ENABLE_SAMBA=0
 
 ## Turn auto night mode on or off (0/1)
 AUTO_NIGHT_MODE=0
+
+## Mirror camera (0/1)
+MIRRORED=0

--- a/sdcard/firmware/scripts/.boot.sh
+++ b/sdcard/firmware/scripts/.boot.sh
@@ -212,6 +212,15 @@ else
     sh ${SD_MOUNTDIR}/firmware/etc/init/S99restartd stop
 fi
 
+####################################
+## Mirrored mode                  ##
+####################################
+
+if [ "$MIRRORED" -eq 1 ]
+then
+    flip on
+    mirror on
+fi
 
 ##################################################################################
 ## Cleanup                                                                      ##

--- a/sdcard/firmware/scripts/.boot.sh
+++ b/sdcard/firmware/scripts/.boot.sh
@@ -213,10 +213,10 @@ else
 fi
 
 ####################################
-## Mirrored mode                  ##
+## Ceiling camera mode            ##
 ####################################
 
-if [ "$MIRRORED" -eq 1 ]
+if [ "$CEILING_MODE" -eq 1 ]
 then
     flip on
     mirror on


### PR DESCRIPTION
**Description:**

When you are installing a camera on the ceil the image will look unnatural. There is an option in Mi Home app to flip the camera but there is no possibility to flip that on load when you are using this hack.

**Proposed solution:**
- Add `MIRRORED` option to `config.cfg`.
- Reuse methods `flip` and `mirror` from `functions.sh`.